### PR TITLE
Add a way to specify Istio gateways

### DIFF
--- a/pkg/apis/networking/v1alpha3/virtualservice_types.go
+++ b/pkg/apis/networking/v1alpha3/virtualservice_types.go
@@ -32,8 +32,9 @@ type VirtualServiceSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
-	Hosts []string     `json:"hosts,omitempty"`
-	Http  []*HTTPRoute `json:"http,omitempty"`
+	Hosts    []string     `json:"hosts,omitempty"`
+	Gateways []string     `json:"gateways,omitempty"`
+	Http     []*HTTPRoute `json:"http,omitempty"`
 }
 
 // VirtualServiceStatus defines the observed state of VirtualService

--- a/pkg/apis/networking/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/networking/v1alpha3/zz_generated.deepcopy.go
@@ -141,6 +141,11 @@ func (in *VirtualServiceSpec) DeepCopyInto(out *VirtualServiceSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Gateways != nil {
+		in, out := &in.Gateways, &out.Gateways
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Http != nil {
 		in, out := &in.Http, &out.Http
 		*out = make([]*HTTPRoute, len(*in))

--- a/pkg/controller/trafficsplit/trafficsplit_controller.go
+++ b/pkg/controller/trafficsplit/trafficsplit_controller.go
@@ -2,6 +2,7 @@ package trafficsplit
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"strings"
 
@@ -202,6 +203,10 @@ func newVSForCR(cr *splitv1alpha1.TrafficSplit) *networkingv1alpha3.VirtualServi
 		backends = append(backends, r)
 	}
 
+	gatewaysStr := cr.ObjectMeta.Annotations["VirtualService.v1alpha3.networking.istio.io/spec.gateways"]
+	var gateways []string
+	_ = json.Unmarshal([]byte(gatewaysStr), &gateways)
+
 	return &networkingv1alpha3.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Name + "-vs",
@@ -210,7 +215,8 @@ func newVSForCR(cr *splitv1alpha1.TrafficSplit) *networkingv1alpha3.VirtualServi
 		},
 
 		Spec: networkingv1alpha3.VirtualServiceSpec{
-			Hosts: []string{cr.Spec.Service},
+			Hosts:    []string{cr.Spec.Service},
+			Gateways: gateways,
 
 			Http: []*networkingv1alpha3.HTTPRoute{
 				{


### PR DESCRIPTION
Example:
```
apiVersion: split.smi-spec.io/v1alpha1
kind: TrafficSplit
metadata:
  annotations:
    VirtualService.v1alpha3.networking.istio.io/spec.gateways: |
      ["bookinfo-gateway", "foo"]
```
Would generate the following:
```
apiVersion: networking.istio.io/v1alpha3
kind: VirtualService
spec:
  gateways:
  - bookinfo-gateway
  - foo
```

---

Partially address https://github.com/deislabs/smi-adapter-istio/issues/7