### PR TITLE
Operator RBAC: Change the reference to ClusterRole

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -68,6 +68,6 @@ subjects:
     name: smi-adapter-istio
     namespace: istio-system
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: smi-adapter-istio
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Fix `ClusterRoleBinding` `smi-adapter-istio` referencing `Role` instead
of `ClusterRole`, which is assigned to the Operator's service account.
