### PR TITLE
Add CODEOWNERS and governance to smi-adapter-istio

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# Maintainers: @alban @surajssd @slack @stefanprodan @lachie83
+CODEOWNERS @alban @surajssd @slack @stefanprodan @lachie83
+CONTRIBUTING.md @alban @surajssd @slack @stefanprodan @lachie83
+LICENSE @alban @surajssd @slack @stefanprodan @lachie83
+GOVERNANCE.md @alban @surajssd @slack @stefanprodan @lachie83

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,34 @@
 # Contributing
 
 ## Support Channels
+
 Whether you are a user or contributor, official support channels include:
+
 - [Issues](https://github.com/deislabs/smi-spec/issues)
 - #general Slack channel in the [SMI Slack](https://smi-spec.slack.com)
 
 ## CLA Requirement
+
 This project welcomes contributions and suggestions. Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repositories using our CLA.
 
 ## Code of Conduct
+
 This project has adopted the [Microsoft Open Source Code of conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact opencode@microsoft.com (mailto:opencode@microsoft.com) with any additional questions or comments.
 
 ## Developer setup
 
-#### Prerequisites
+### Prerequisites
 
 - Minikube machine with atleast `4GB` memory.
 - `operator-sdk` installed, download from [here](https://github.com/operator-framework/operator-sdk/releases).
 
-#### Download Istio
+### Download Istio
 
 Follow [instructions in istio documentation](https://istio.io/docs/setup/kubernetes/download/#download-and-prepare-for-the-installation) to download istio.
 
-#### Install Istio
+### Install Istio
 
 Once you are the root of the downloaded directory. Run following command to install Istio.
 
@@ -34,7 +38,7 @@ kubectl apply -f install/kubernetes/istio-demo-auth.yaml
 
 Verify the istio is running fine as mentioned [here](https://istio.io/docs/setup/kubernetes/install/kubernetes/#verifying-the-installation).
 
-#### Now build the operator image
+### Now build the operator image
 
 ```bash
 eval $(minikube docker-env)
@@ -43,14 +47,14 @@ operator-sdk build devimage
 
 By exporting all the minikube docker environment variables locally the build happens in the virtual machine directly.
 
-#### Deploy the operator and related configs
+### Deploy the operator and related configs
 
 ```bash
 kubectl apply -R -f deploy/
 cat deploy/operator.yaml | sed 's|OPERATOR_IMAGE|devimage|g'| sed 's|imagePullPolicy: Always|imagePullPolicy: Never|g' | kubectl apply -f -
 ```
 
-#### To rebuild and redeploy
+### To rebuild and redeploy
 
 After making changes to the code run following commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,10 @@ When you submit a pull request, a CLA-bot will automatically determine whether y
 This project has adopted the [Microsoft Open Source Code of conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact opencode@microsoft.com (mailto:opencode@microsoft.com) with any additional questions or comments.
 
+## Project Governance
+
+Project maintainership is outlined in the [GOVERNANCE](GOVERNANCE.md) file.
+
 ## Developer setup
 
 ### Prerequisites

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,15 @@
+# Governance
+
+## Project Maintainers
+
+[Project maintainers](CODEOWNERS) are responsible for activities around maintaining and updating the SMI Adapter for Istio. Final decisions on the project reside with the project maintainers.
+
+Changes to the code base require approval from one project maintainer.
+
+Maintainers MUST remain active. If they are unresponsive for >3 months, they will be automatically removed unless a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the other project maintainers agrees to extend the period to be greater than 3 months.
+
+New maintainers can be added to the project by a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) vote of the existing maintainers. A potential maintainer may be nominated by an existing maintainer. A vote is conducted in private between the current maintainers over the course of a one week voting period. At the end of the week, votes are counted and a pull request is made on the repo adding the new maintainer to the [CODEOWNERS](CODEOWNERS) file.
+
+A maintainer may step down by submitting an [issue](https://github.com/deislabs/smi-adapter-istio/issues/new) stating their intent.
+
+Changes to this governance document require a pull request with approval from a [super-majority](https://en.wikipedia.org/wiki/Supermajority#Two-thirds_vote) of the current maintainers.


### PR DESCRIPTION
After this change is merged we will enable branch protection for master, requiring review from one reviewer.

CODEOWNERS is limited to the "infrastructure" files so not every owner is notified on every PR.