### PR TITLE
re-add setup_remote_docker line

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,7 @@ jobs:
     working_directory: /go/src/github.com/deislabs/smi-adapter-istio
     steps:
       - checkout
+      - setup_remote_docker
       - run:
           name: build and push image
           command: |


### PR DESCRIPTION
Still need the setup_remote_docker line to build/push images in circle so adding that back in.