### PR TITLE
Updated API version for trafficsplit

### DIFF
--- a/docs/smi-trafficsplit/manifests/02-traffic-split-1000-0.yaml
+++ b/docs/smi-trafficsplit/manifests/02-traffic-split-1000-0.yaml
@@ -1,4 +1,4 @@
-apiVersion: split.smi-spec.io/v1alpha1
+apiVersion: split.smi-spec.io/v1alpha2
 kind: TrafficSplit
 metadata:
   name: reviews-rollout

--- a/docs/smi-trafficsplit/manifests/04-traffic-split-900-100.yaml
+++ b/docs/smi-trafficsplit/manifests/04-traffic-split-900-100.yaml
@@ -1,4 +1,4 @@
-apiVersion: split.smi-spec.io/v1alpha1
+apiVersion: split.smi-spec.io/v1alpha2
 kind: TrafficSplit
 metadata:
   name: reviews-rollout

--- a/docs/smi-trafficsplit/manifests/05-traffic-split-750-250.yaml
+++ b/docs/smi-trafficsplit/manifests/05-traffic-split-750-250.yaml
@@ -1,4 +1,4 @@
-apiVersion: split.smi-spec.io/v1alpha1
+apiVersion: split.smi-spec.io/v1alpha2
 kind: TrafficSplit
 metadata:
   name: reviews-rollout

--- a/docs/smi-trafficsplit/manifests/06-traffic-split-200-800.yaml
+++ b/docs/smi-trafficsplit/manifests/06-traffic-split-200-800.yaml
@@ -1,4 +1,4 @@
-apiVersion: split.smi-spec.io/v1alpha1
+apiVersion: split.smi-spec.io/v1alpha2
 kind: TrafficSplit
 metadata:
   name: reviews-rollout

--- a/docs/smi-trafficsplit/manifests/07-traffic-split-0-1000.yaml
+++ b/docs/smi-trafficsplit/manifests/07-traffic-split-0-1000.yaml
@@ -1,4 +1,4 @@
-apiVersion: split.smi-spec.io/v1alpha1
+apiVersion: split.smi-spec.io/v1alpha2
 kind: TrafficSplit
 metadata:
   name: reviews-rollout


### PR DESCRIPTION
I was unable to run the example: https://github.com/deislabs/smi-adapter-istio/tree/master/docs/smi-trafficsplit (`no matches for kind "TrafficSplit" in version "split.smi-spec.io/v1alpha1"`) - so I have updated the API versions and run it successfully from my fork.