### PR TITLE
kustomize support to deploy smi-adapter

### DIFF
--- a/deploy/kustomization.yaml
+++ b/deploy/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+- operator-and-rbac.yaml
+- ./crds/crds.yaml


### PR DESCRIPTION
Added a kustomization.yaml file to use as a base for deploying the operators to cluster using [Kustomize](https://github.com/kubernetes-sigs/kustomize)